### PR TITLE
Unify tag endpoint response type

### DIFF
--- a/app/controllers/tags_controller.rb
+++ b/app/controllers/tags_controller.rb
@@ -1,22 +1,22 @@
 class TagsController < ApplicationController
-
   def index
-    @tags =  Tag.search(params[:q])
+    render partial: 'tag_properties', locals: { tags: Tag.search(params[:q])}
   end
 
   def popular
-    render json: Tag.get_tags_that_are(:popular), status: 200
+    render partial: 'tag_properties', locals: { tags: Tag.get_tags_that_are(:popular) }
   end
 
   def recent
-    render json: Tag.get_tags_that_are(:recent), status: 200
+    render partial: 'tag_properties', locals: { tags: Tag.get_tags_that_are(:recent) }
   end
 
   def trending
-    render json: Tag.get_tags_that_are(:trending), status: 200
+    render partial: 'tag_properties', locals: { tags: Tag.get_tags_that_are(:trending) }
   end
 
   def update_subscription
     current_user.tags = Tag.process_tags(params[:tags])
+    render partial: 'tag_properties', locals: { tags: current_user.tags }
   end
 end

--- a/app/controllers/tags_controller.rb
+++ b/app/controllers/tags_controller.rb
@@ -3,16 +3,10 @@ class TagsController < ApplicationController
     render partial: 'tag_properties', locals: { tags: Tag.search(params[:q])}
   end
 
-  def popular
-    render partial: 'tag_properties', locals: { tags: Tag.get_tags_that_are(:popular) }
-  end
-
-  def recent
-    render partial: 'tag_properties', locals: { tags: Tag.get_tags_that_are(:recent) }
-  end
-
-  def trending
-    render partial: 'tag_properties', locals: { tags: Tag.get_tags_that_are(:trending) }
+  %i(popular recent trending).each do |action|
+    define_method(action) do
+      render partial: 'tag_properties', locals: { tags: Tag.get_tags_that_are(action) }
+    end
   end
 
   def update_subscription

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -58,8 +58,7 @@ class UsersController < ApplicationController
   end
 
   def tags
-    @tags = @user.tags
-    render 'tags/index'
+    render partial: 'tags/tag_properties', locals: { tags: @user.tags }
   end
 
   private

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -15,13 +15,14 @@ class Tag < ActiveRecord::Base
 
   class << self
     def get_tags_that_are(arg)
+      colns = 'name, id, representative_id, COUNT(name) as count_id'
       case arg
       when :recent
-        all.order('id DESC')
+        all.order('id DESC').select(:name, :id, :representative_id)
       when :popular
-        group(:name).order('count_id DESC').count('id')
+        select(colns).group(:name).order('count_id DESC')
       when :trending
-        group('name').order('count_id DESC, DATE(created_at) DESC').count('id')
+        select(colns).group(:name).order('count_id DESC, DATE(created_at) DESC')
       end
     end
 

--- a/app/views/tags/_tag_properties.json.jbuilder
+++ b/app/views/tags/_tag_properties.json.jbuilder
@@ -1,0 +1,3 @@
+json.tags do
+  json.array!(tags){|tag| json.extract! tag, :id, :name, :representative_id }
+end

--- a/app/views/tags/index.json.jbuilder
+++ b/app/views/tags/index.json.jbuilder
@@ -1,1 +1,0 @@
-json.partial! 'tags/tag', tags: @tags

--- a/app/views/tags/update_subscription.json.jbuilder
+++ b/app/views/tags/update_subscription.json.jbuilder
@@ -1,1 +1,0 @@
-json.partial! 'tags/tag', tags: current_user.tags

--- a/docs/tags_endpoints.md
+++ b/docs/tags_endpoints.md
@@ -6,6 +6,7 @@ GET /tags/?q=query |	Returns the tags that match the given the argument (autocom
 GET /tags/popular | Returns the popular tags | True
 GET /tags/recent | Returns the recent tags | True
 GET /tags/trending | Returns the trending tags | True
+POST /tags/update_subscription | Returns the users tags | True
 
 ### GET /tags/?q=query
 
@@ -20,7 +21,13 @@ Response
 ```ruby
 Status: 200
   {
-    matches: ["mac", "machine", "mac-book", "mac-book"]
+    tags: [
+      {
+        name: 'mac',
+        id: 1,
+        representative_id: nil
+      }
+    ]
   }
 ```
 
@@ -37,7 +44,13 @@ Response
 ```ruby
 Status: 200
 {
-  tags: ["#simulations", "#mac-book", "#checkpoint", "#accommodation", "#promotion"]
+  tags: [
+    {
+      name: 'mac',
+      id: 1,
+      representative_id: nil
+    }
+  ]
 }
 ```
 > Might be paginated
@@ -47,7 +60,13 @@ Response
 ```ruby
 Status: 200
 {
-  tags: ["#simulations", "#mac-book", "#checkpoint", "#accommodation", "#promotion"]
+  tags: [
+    {
+      name: 'mac',
+      id: 1,
+      representative_id: nil
+    }
+  ]
 }
 ```
 
@@ -56,6 +75,39 @@ Response
 ```ruby
 Status: 200
 {
-  tags: ["#simulations", "#mac-book", "#checkpoint", "#accommodation", "#promotion"]
+  tags: [
+    {
+      name: 'mac',
+      id: 1,
+      representative_id: nil
+    }
+  ]
+}
+```
+
+### POST /tags/update_subscription
+Request
+```ruby
+{
+  tags: 'tag1, tag2'
+}
+```
+
+Response
+```ruby
+Status: 200
+{
+  tags: [
+    {
+      name: 'tag1',
+      id: 1,
+      representative_id: nil
+    },
+    {
+      name: 'tag2',
+      id: 2,
+      representative_id: nil
+    }
+  ]
 }
 ```

--- a/docs/user_endpoints.md
+++ b/docs/user_endpoints.md
@@ -109,7 +109,18 @@ Response
 ```ruby
 Status: 200
   {
-    tags: ["operations", "andela"]
+    tags: [
+      {
+        name: 'operations',
+        id: 1,
+        representative_id: nil
+      },
+      {
+        name: 'andela',
+        id: 2,
+        representative_id: nil
+      }
+    ]
   }
 ```
 

--- a/spec/models/tag_spec.rb
+++ b/spec/models/tag_spec.rb
@@ -17,23 +17,17 @@ RSpec.describe Tag, type: :model do
   describe ".get_tags_that_are" do
     let(:arg) { :popular }
     it "sorts the tags in popular order" do
-      expect(Tag.get_tags_that_are(arg)).to be_a Hash
-      expect(Tag.get_tags_that_are(arg).first.first).to eq("contract")
-      expect(Tag.get_tags_that_are(arg).first.last).to eq(5)
-      expect(Tag.get_tags_that_are(arg).keys.last).to eq("kaizen")
-      expect(Tag.get_tags_that_are(arg).values.last).to eq(2)
-     end
+      expect(Tag.get_tags_that_are(arg).first.name).to eq("contract")
+      expect(Tag.get_tags_that_are(arg).last.name).to eq("kaizen")
+    end
   end
 
   describe ".get_tags_that_are" do
     let(:arg) { :trending }
     it "sorts the tags in trending order" do
       create_list(:tag, 7, name: "Kaizen")
-      expect(Tag.get_tags_that_are(arg)).to be_a Hash
-      expect(Tag.get_tags_that_are(arg).first.first).to eq("kaizen")
-      expect(Tag.get_tags_that_are(arg).first.last).to eq(9)
-      expect(Tag.get_tags_that_are(arg).keys.last).to eq("amity")
-      expect(Tag.get_tags_that_are(arg).values.last).to eq(3)
+      expect(Tag.get_tags_that_are(arg).first.name).to eq("kaizen")
+      expect(Tag.get_tags_that_are(arg).last.name).to eq("amity")
      end
   end
 

--- a/spec/requests/tags_request_spec.rb
+++ b/spec/requests/tags_request_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe TagsController, type: :request do
       allow(Tag).to receive(:search).and_return([contract_tag])
       get tags_path, {q: "contract", format: :json}, authorization_header
       expect(status).to eq 200
-      expect(response).to match_response_schema("tag/index")
+      expect(response).to match_response_schema("tag/tag_properties")
     end
   end
 
@@ -21,41 +21,41 @@ RSpec.describe TagsController, type: :request do
     it "returns status 200 with all tags ordered by the popular ones" do
       get popular_tags_path, {format: :json}, authorization_header
 
-      expect(parsed_json).to have_key("contract")
+      expect(parsed_json['tags'].first).to have_value("contract")
       expect(status).to eq 200
+      expect(response).to match_response_schema("tag/tag_properties")
     end
   end
 
   describe "GET /tags/recent" do
     it "returns status 200 with all tags ordered by the recently created ones" do
-
       get recent_tags_path, {format: :json}, authorization_header
 
-      expect(parsed_json.first["id"]).to eq(Tag.last.id)
-      expect(parsed_json.last["id"]).to eq(Tag.first.id)
-      expect(parsed_json.count).to eq(Tag.count)
+      expect(parsed_json['tags'].first["id"]).to eq(Tag.last.id)
+      expect(parsed_json['tags'].last["id"]).to eq(Tag.first.id)
+      expect(parsed_json['tags'].count).to eq(Tag.count)
       expect(status).to eq 200
+      expect(response).to match_response_schema("tag/tag_properties")
     end
   end
 
   describe "GET /tags/trending" do
     it "returns status 200 with all tags ordered by the trending ones" do
-
       get trending_tags_path, {format: :json}, authorization_header
 
-      expect(parsed_json.first.last).to eq(parsed_json.values.max)
+      expect(parsed_json['tags'].first['name']).to eq('contract')
       expect(status).to eq 200
+      expect(response).to match_response_schema("tag/tag_properties")
     end
   end
 
   describe "POST /tags/update_subscription" do
     it "returns 200 status" do
-
       post update_subscription_tags_path, {tags: "contract", format: :json}, authorization_header
-      expect(parsed_json).to be_a Hash
-      expect(parsed_json.keys.count).to eq(1)
-      expect(parsed_json.keys).to include("tags")
+      expect(parsed_json['tags'].size).to eq(1)
+      expect(parsed_json['tags'].first['name']).to eql("contract")
       expect(status).to eq 200
+      expect(response).to match_response_schema("tag/tag_properties")
     end
   end
 

--- a/spec/requests/users_request_spec.rb
+++ b/spec/requests/users_request_spec.rb
@@ -52,9 +52,8 @@ RSpec.describe "Users", type: :request do
     it "retrieves all the tags a user has subscribed to" do
       get tags_user_path(user.id), {format: :json}, authorization_header
 
-      expect(parsed_json).to have_key('tags')
       expect(parsed_json['tags'].size).to eql(total_tags)
-      expect(response).to match_response_schema('tag/index')
+      expect(response).to match_response_schema('tag/tag_properties')
     end
   end
 end

--- a/spec/support/schemas/tag/tag_properties.json
+++ b/spec/support/schemas/tag/tag_properties.json
@@ -1,0 +1,18 @@
+{
+  "type": "object",
+  "properties":{
+    "tags": {
+    "type": ["array"],
+    "properties":{
+      "type": "object",
+      "properties":{
+        "name": { "type": "string" },
+        "representative_id": { "type": ["integer", null] },
+        "id": { "type": "integer" }
+        },
+      "required": ["name", "representative_id", "id"]
+      }
+    }
+  },
+  "required": ["tags"]
+}


### PR DESCRIPTION
The tag endpoints, recent, trending, popular, index, update_subscription return differing response object which can be a pain to handle. Some return an object, a couple return an array and some just the status code.
This implements a common response structure accross all the endpoint; an object with tags as key and an array of tag objects (containing tag :name, :id and :representative_id) as values. This is achieved by doing the following:

* modify tag queries to return a serializable collection
* create a new partial, tag_properties to serialize the collection as desired
* replace all former serializers with the new one
* Update the test and JSON scheme files