### PR TITLE
Added Personalized Questions Route and Implementation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,5 @@ association_count.rb
 /coverage/*
 /.coveralls.yml
 .DS_Store
+/.backup
+.codesnip

--- a/app/controllers/questions_controller.rb
+++ b/app/controllers/questions_controller.rb
@@ -7,6 +7,12 @@ class QuestionsController < ApplicationController
     @questions = PaginationPresenter.new(questions)
   end
 
+  def personalized
+    questions = Question.personalized(current_user).paginate(page: params[:page])
+    @questions = PaginationPresenter.new(questions)
+    render :index
+  end
+
   def show
     @question.increment_views
   end

--- a/app/models/concerns/votes_counter.rb
+++ b/app/models/concerns/votes_counter.rb
@@ -13,7 +13,7 @@ module VotesCounter
     }
 
     scope :by_date, -> {
-      with_votes.order('created_at DESC')
+      with_votes.order("#{table_name}.created_at DESC")
     }
   end
 

--- a/app/models/queries/user_questions_query.rb
+++ b/app/models/queries/user_questions_query.rb
@@ -1,0 +1,45 @@
+module Queries
+  class UserQuestionsQuery
+    attr_reader :user
+
+    def initialize(user)
+      @user = user
+    end
+
+    def call
+      Question.with_basic_association.joins(:tags).where(user_subscriptions).distinct
+    end
+
+    private
+      def user_subscriptions
+        tag_table[:id].in(user_tag_association).or(tag_table[:representative_id].in(user_tag_association))
+      end
+
+      def user_model
+        user.model_name.to_s
+      end
+
+      def user_id
+        user.id
+      end
+
+      def tag_table
+        Tag.arel_table
+      end
+
+      def resource_tag_table
+        ResourceTag.arel_table
+      end
+
+      def resource_tag_to_user_assocation
+        resource_tag_table[:taggable_type].eq(user_model).and(resource_tag_table[:taggable_id].eq(user_id))
+      end
+
+      def user_tag_association
+        tag_table.project(tag_table[:id]).
+        join(resource_tag_table).
+        on(tag_table[:id].eq(resource_tag_table[:tag_id])).
+        where(resource_tag_to_user_assocation)
+      end
+  end
+end

--- a/app/models/question.rb
+++ b/app/models/question.rb
@@ -25,6 +25,10 @@ class Question < ActiveRecord::Base
     nil
   end
 
+  def self.personalized(user)
+    Queries::UserQuestionsQuery.new(user).call
+  end
+
   def self.with_associations
     eager_load(:votes)
       .eager_load(answers: [{comments: [{user: [:social_providers]}, :votes]}, {user: [:social_providers]}, :votes])

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -13,6 +13,7 @@ Rails.application.routes.draw do
     resources :questions, except: [:new, :edit] do
       collection do
         get :search
+        get :personalized
       end
       member do
         get "recent_answers"

--- a/docs/questions_endpoints.md
+++ b/docs/questions_endpoints.md
@@ -9,6 +9,7 @@ GET questions/top_questions | offset, limit ( both could be optional ), auth_tok
 PUT questions/:id| question's id, update information(title, description), auth_token in header | Returns the updated question and all the information concerning it  or error message if any.
 DELETE questions/:id| question's id, auth_token in header | Returns a confirmation that the question has been deleted  or error message if any.
 GET questions/search | `q` which has the value of the params to search | Returns an array of questions, with a few things stripped off, such as association counts etc
+GET questions/personalized | offset, limit ( both could be optional ), auth_token in header | Returns all questions based on the tags a user has subscribed to with all the basic data
 
 ## GET /questions/
 Request

--- a/spec/models/queries/user_questions_query_spec.rb
+++ b/spec/models/queries/user_questions_query_spec.rb
@@ -1,0 +1,30 @@
+require 'rails_helper'
+
+RSpec.describe Queries::UserQuestionsQuery do
+  let(:user) { create(:user) }
+  let(:subject) { described_class.new(user) }
+
+  before do
+    create_list(:user_resource_tag, 2, taggable: user) do |resource_tag|
+      create_list(:question, 5, tags: [resource_tag.tag])
+    end
+  end
+
+  describe "#call" do
+    it "fetches all questions a user has subscribed to" do
+      questions = subject.call.to_a
+
+      expect(questions.size).to eq 10
+    end
+  end
+
+  describe "#user_subscriptions" do
+    it "calls the user_subscriptions method" do
+      allow(subject).to receive(:user_subscriptions)
+
+      questions = subject.call
+
+      expect(subject).to have_received(:user_subscriptions)
+    end
+  end
+end

--- a/spec/requests/questions/personalized_question_spec.rb
+++ b/spec/requests/questions/personalized_question_spec.rb
@@ -1,0 +1,52 @@
+require "rails_helper"
+
+RSpec.describe "Personalized Questions", type: :request do
+  describe "GET /personalized" do
+    let(:path) { personalized_questions_path }
+
+    context "when user has subscribed to tags and questions exists for the tags" do
+      before(:each) do
+        create_list(:user_resource_tag, 2, taggable: valid_user) do |resource_tag|
+          create_list(:question, 5, tags: [resource_tag.tag])
+        end
+
+        get path, { format: :json }, authorization_header
+      end
+
+      it "should return status 200" do
+        expect(response.status).to eq(200)
+      end
+
+      it "should return questions in the tags subscribed to" do
+        expect(parsed_json["questions"].size).to eql 10
+      end
+
+      it "should match the template definition" do
+        expect(response).to match_response_schema('question/index')
+      end
+    end
+
+
+    context "when user has subscribed to tags but no questions exists for the tag" do
+      before(:each) do
+        create_list(:user_resource_tag, 3, taggable: valid_user)
+        create_list(:question_with_tags, 10)
+
+        get path, { format: :json }, authorization_header
+      end
+
+      it "should not return any questions" do
+        expect(parsed_json['questions'].size).to eql 0
+      end
+    end
+
+
+    context "when user has not subscribed for a tag" do
+      it "should not return any question" do
+        get path, { format: :json }, authorization_header
+
+        expect(parsed_json['questions'].size).to eql 0
+      end
+    end
+  end
+end


### PR DESCRIPTION
As the application is growing, in order for users to engage with the platform more, they would like to see questions/topics personalized to their interests.

This PR ensures that once a user has subscribed to a tag or tags, when they come to a personalized question page they can see all questions personalized to their interest.
This addition should also be useful in the newsletter which would need to carry content personalized to the user.